### PR TITLE
extend content_script matches to popout player url

### DIFF
--- a/common/manifest.json
+++ b/common/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "TTV ad-block",
-	"version": "2.0.0",
+	"version": "2.1.0",
 	"description": "Block ads on that certain streaming website",
 	"manifest_version": 2,
 	"background": {
@@ -9,7 +9,7 @@
 	},
 	"content_scripts": [
 		{
-			"matches": ["*://www.twitch.tv/*"],
+			"matches": ["*://www.twitch.tv/*", "*://player.twitch.tv/*"],
 			"js": ["content.js"],
 			"run_at": "document_start"
 		}


### PR DESCRIPTION
This updates the `content_scripts` url match parameters to include `player.twitch.tv` so ads are circumvented when using the popout player. Fixes #14.

Tested and working on Windows 10 / Firefox 83.0.

If others want to help test on various OS/browsers that would be great.

## Firefox users:
- clone this repo locally
- in Firefox, open a tab to `about:debugging`
- on the left menu click "This Firefox"
- click the "Load Temporary Extension" button and load `manifest.json`

## Chrome users:
- clone this repo locally
- open a tab to `chrome://extensions`
- expand the developer dropdown menu and click "Load Unpacked Extension"
- load `manifest.json`

Browse a couple streams and load the popout player. Hopefully you get no preroll/midroll ads!